### PR TITLE
Fix: When enviroments have $params to false, they get set anyways

### DIFF
--- a/Lib/Environment.php
+++ b/Lib/Environment.php
@@ -110,8 +110,8 @@ class Environment {
 			return false;
 		}
 
-		if ($params === true) {
-			return true;
+		if (is_bool ($params)) {
+			return $params;
 		}
 
 		foreach ($params as $param => $value) {


### PR DESCRIPTION
This pull fixes the issue where environments with $params set to `false` got loaded. 
