### PR TITLE
bootstraping the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Your `environments.php` should contain the following:
 
 	Environment::start();
 
+Then, you need to include the `environments.php` file you created in your application, for example in `bootstrap.php`:
+
+	include dirname(__FILE__) . DS . 'bootstrap' . DS . 'environments.php';
+
 This will:
 
 - Load the environments plugin in cases where it may not already be loaded


### PR DESCRIPTION
I couldn't find In the readme nor the source code a built in way to initialize the plugin. I had to include the `environments.php` file in my `app/Config/bootstrap.php`, but then doing `CakePlugin::load('Environments')` was not necessary. 

I added a `bootstrap.php` file in the plugin's Config directory, and updated the README to indicate that you should bootstrap the plugin within the `CakePlugin::load` or `CakePlugin::loadAll` methods.

As a plus, I added working database config in the `development.php` environment example, that correctly loads if using the proposed database config file.

Cheers!
